### PR TITLE
fix: every key press changing language when focus language globe

### DIFF
--- a/src/components/LanguageSwitch/index.jsx
+++ b/src/components/LanguageSwitch/index.jsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useState } from "react";
-import cx from "classnames";
 
 import * as styles from "./LanguageSwitch.module.css";
 import Icon from "../Icon";
@@ -48,8 +47,7 @@ const LanguageSwitch = () => {
       <div className={styles.LanguageSwitchCurrent}
         role="button"
         tabIndex="0"
-        onClick={toggleLang}
-        onKeyDown={toggleLang}>
+        onClick={toggleLang}>
         <Shortcut command={shortcuts.languageSwitch} />
         <span>{langNames[lang]}</span>
         <Icon


### PR DESCRIPTION
On click after language change globe, every key presses can change language.

![change-language-key-bug](https://user-images.githubusercontent.com/49279517/142201281-aee165c1-6181-4461-9494-c5c70c167046.gif)