### PR TITLE
fix typo in lesson 52

### DIFF
--- a/src/localization/en-us.json
+++ b/src/localization/en-us.json
@@ -261,7 +261,7 @@
   "steps.flagsMultiline.description": "RegEx sees all text as one line. But we use the `multiline` flag to handle each line separately. In this way, the expressions we write according to the end of the linework separately for each line. Now enable the `multiline` flag to find all matches.",
 
   "steps.flagsCaseInsensitive.title": "Case-insensitive Flag",
-  "steps.flagsCaseInsensitive.description": "In order to remove the case-insensitiveness of the expression we have written, we must activate the `case-insensitive` flag.",
+  "steps.flagsCaseInsensitive.description": "In order to remove the case-sensitiveness of the expression we have written, we must activate the `case-insensitive` flag.",
   
   "steps.greedyMatching.title": "Greedy Matching",
   "steps.greedyMatching.description": "RegEx does a greedy match by default. This means that the matchmaking will be as long as possible. Check out the example below. It refers to any match that ends in `r` and can be any character preceded by it. But it does not stop at the first letter `r`.",


### PR DESCRIPTION
This fixes a typo in the English localization of lesson 52. The correct text is:

"In order to remove the case-**sensitiveness** of the expression we have written, we must activate the `case-insensitive` flag."