### PR TITLE
Update regex101.js

### DIFF
--- a/src/data/lessons/regex101.js
+++ b/src/data/lessons/regex101.js
@@ -376,7 +376,7 @@ const regex101 = [
     initialValue: '(C|c)at',
     initialFlags: 'g',
     flags: 'g',
-    regex: ['(C|c)at|rat'],
+    regex: ['(C|c)at|rat', '(C|c|r)at'],
     cursorPosition: 7,
     answer: ['cat', 'Cat', 'rat'],
   },


### PR DESCRIPTION
Alternation
'(C|c)at|rat'  Same match as '(C|c|r)at'