### PR TITLE
Fix: automatically triggered regex result when the page is displayed

### DIFF
--- a/src/components/InteractiveArea.tsx
+++ b/src/components/InteractiveArea.tsx
@@ -254,6 +254,7 @@ const InteractiveArea = ({ isShow, setIsOpenModal }: Props) => {
             readOnly={data.readOnly}
             value={data.visibleRegex || regex}
             onChange={onChange}
+            onFocus={onChange}
             placeholder={placeholder}
             spellCheck={false}
           />


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/21235555/201813973-1c9eabac-a99a-40d9-a92a-4e9e7ae537da.png)



now
![image](https://user-images.githubusercontent.com/21235555/201813984-b8b7191b-ca05-496e-9118-f30859604995.png)
