### PR TITLE
Give header fixed 5rem height to prevent scroll.

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -18,7 +18,7 @@ const Header = ({ page }: Props) => {
 
   return (
     <header
-      className={cx('relative z-40', {
+      className={cx('relative z-40 h-20', {
         'bg-neutral-800 px-4 border-b border-neutral-700': isPlaygroundPage,
       })}
     >


### PR DESCRIPTION
- Problem: In the `playground` page,  component height was set to `100vh - 5rem` but header was not exatcly 5rem of height and these make scrollbar appears even though there is no need to scroll.
- Solution: Header is now set to 5rem of height to make it easy to use in the future case like this.