### PR TITLE
Add dynamic generation of sitemap and robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-error.log*
 .idea
 .next
 out
+public/robots.txt
+public/sitemap*

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_BASE_URL,
+  generateRobotsTxt: true,
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "next dev -p 3003",
     "build": "next build",
+    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint",
     "export": "next export",
@@ -40,6 +41,7 @@
     "autoprefixer": "^10.4.13",
     "eslint": "^8.34.0",
     "eslint-config-next": "^13.2.1",
+    "next-sitemap": "^4.1.8",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
     "typescript": "^4.9.5"


### PR DESCRIPTION
I've noticed that the project was missing a sitemap and a robots.txt file. Including these can significantly improve the site's SEO and accessibility for search engines.

Here are the key changes implemented:

- Included `next-sitemap` package in devDependencies.
- Introduced `next-sitemap.config.js` for managing dynamic file generation.
- Adjusted `postbuild` script in package.json to utilize next-sitemap.
- Set the output directory for generated files to `public`.
- Listed these dynamically created files in .`gitignore` to prevent committing.


Upon completion of the build process, these files will be available within the public folder.

**public folder**
<img width="209" alt="Screenshot 2023-07-21 at 23 29 49" src="https://github.com/aykutkardas/regexlearn.com/assets/27916419/b169066a-5f32-4177-88ef-14191b9f7736">

**robots.txt**
<img width="342" alt="Screenshot 2023-07-21 at 23 32 48" src="https://github.com/aykutkardas/regexlearn.com/assets/27916419/cd242e93-69aa-4ce9-97ff-7f712c2588da">

**sitemap.xml**
![sitemap](https://github.com/aykutkardas/regexlearn.com/assets/27916419/8fe2510c-da3d-4e23-a1fb-edd0fc401354)

**sitemap-0.xml**
![sitemap-0](https://github.com/aykutkardas/regexlearn.com/assets/27916419/5411458e-46b6-4ca9-903d-507fb104b983)

