### PR TITLE
Add missing period regexForSeo.js

### DIFF
--- a/src/data/lessons/regexForSeo.js
+++ b/src/data/lessons/regexForSeo.js
@@ -181,7 +181,7 @@ const regexForSeo = [
     noHint: true,
     cursorPosition: 2,
     readOnly: true,
-    visibleRegex: '/*.pdf$',
+    visibleRegex: '/.*.pdf$',
     hiddenFlags: true,
     regex: ['/.*.pdf$'],
     answer: ['/document.pdf', '/introduction.pdf'],


### PR DESCRIPTION
# Problem
Although the Regex was running correctly, had the correct internal value, and was impossible to change, the display value for the Regex was incorrect, which sometimes led to strange errors for the challenge locking if the input was clicked enough.

# Changes
Adds missing period to page 14/17 in Regex for SEO.

# Issues
This closes #334 