### PR TITLE
Fix/remove scroll limitation

### DIFF
--- a/src/components/InteractiveArea.tsx
+++ b/src/components/InteractiveArea.tsx
@@ -144,6 +144,14 @@ const InteractiveArea = ({ isShow, setIsOpenModal }: Props) => {
     applyRegex(e.target.value, flags);
   };
 
+  const onFocus = e => {
+    if (data.readOnly) {
+        return;
+    }
+
+    onChange(e);
+  }
+
   const focusInput = () => {
     regexInput?.current?.focus();
   };
@@ -254,7 +262,7 @@ const InteractiveArea = ({ isShow, setIsOpenModal }: Props) => {
             readOnly={data.readOnly}
             value={data.visibleRegex || regex}
             onChange={onChange}
-            onFocus={onChange}
+            onFocus={onFocus}
             placeholder={placeholder}
             spellCheck={false}
           />

--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -8,7 +8,7 @@ const PlaygroundSidebar = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <div className="overflow-y-scroll lg:overflow-y-hidden p-3 space-y-8 flex-col lg:hover:overflow-y-scroll rounded-md">
+    <div className="overflow-y-scroll p-3 space-y-8 flex-col rounded-md">
       {data.map(row => (
         <div key={row.title} className="bg-neutral-800 rounded-md">
           <div className="mb-3">{formatMessage({ id: row.title })}</div>


### PR DESCRIPTION
Removing limitation for vertical scroll. This limitation creates an accessibility issue where users can't scroll if they're using an input mode that doesn't support hover, such as the touch screen on an iPad Pro.

Related issue: https://github.com/aykutkardas/regexlearn.com/issues/381