### PR TITLE
Fix/add meta viewport

### DIFF
--- a/src/components/InteractiveArea.tsx
+++ b/src/components/InteractiveArea.tsx
@@ -144,6 +144,14 @@ const InteractiveArea = ({ isShow, setIsOpenModal }: Props) => {
     applyRegex(e.target.value, flags);
   };
 
+  const onFocus = e => {
+    if (data.readOnly) {
+        return;
+    }
+
+    onChange(e);
+  }
+
   const focusInput = () => {
     regexInput?.current?.focus();
   };
@@ -254,7 +262,7 @@ const InteractiveArea = ({ isShow, setIsOpenModal }: Props) => {
             readOnly={data.readOnly}
             value={data.visibleRegex || regex}
             onChange={onChange}
-            onFocus={onChange}
+            onFocus={onFocus}
             placeholder={placeholder}
             spellCheck={false}
           />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -42,6 +42,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       {metadata && (
         <Head>
           <title>{metadata.title}</title>
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
           <meta name="description" content={metadata.description} />
           {typeof metadata.hrefLang === 'string' &&
             locales.map(locale => (


### PR DESCRIPTION
Add viewport meta tag with `initial-scale=1` and `maximun-scale=1` to prevent mobile browsers to zoom in on input focus. The user can still zoom in manually

## Before:
https://github.com/user-attachments/assets/cf8fa364-8383-4a1b-8c13-4605da462e4c

## After:
https://github.com/user-attachments/assets/4d99db64-2347-4151-aa04-85ad0c2e507d


**Context about the solution:** https://stackoverflow.com/a/46254706
**Related issue:** https://github.com/aykutkardas/regexlearn.com/issues/301