### PR TITLE
Update learn.json - amend escapes question, using "them" instead of "it"

### DIFF
--- a/src/localization/en/learn.json
+++ b/src/localization/en/learn.json
@@ -99,7 +99,7 @@
   "steps.pipeCharacter.description": "It allows to specify that an expression can be in different expressions. Thus, all possible statements are written separated by the pipe sign `|`. This differs from charset `[abc]`, charsets operate at the character level. Alternatives are at the expression level. For example, the following expression would select both `cat` and `rat`. Add another pipe sign `|` to the end of the expression and type `dog` so that all words are selected.",
 
   "steps.escapeCharacter.title": "Escape Character `\\`",
-  "steps.escapeCharacter.description": "There are special characters that we use when writing regex. `{ } [ ] / \\ + * . $^ | ?` Before we can select these characters themselves, we need to use an escape character `\\`. For example, to select the dot `.` and asterisk `*` characters in the text, let's add an escape character `\\` before it.",
+  "steps.escapeCharacter.description": "There are special characters that we use when writing regex. `{ } [ ] / \\ + * . $^ | ?` Before we can select these characters themselves, we need to use an escape character `\\`. For example, to select the dot `.` and asterisk `*` characters in the text, let's add an escape character `\\` before them.",
 
   "steps.caret.title": "Caret Sign `^`:\\nSelecting by Line Start",
   "steps.caret.description": "We were using `[0-9]` to find numbers. To find only numbers at the beginning of a line, prefix this expression with the `^` sign.",


### PR DESCRIPTION
The description sentence refers to the dot _and_ the asterisk not to just one or the other, thereby "them" being more appropriate.