### PR TITLE
Fix : option+h shortcut not working on mac

### DIFF
--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -16,16 +16,23 @@ interface Props {
 const Hint = ({ regex, flags, hiddenFlags }: Props) => {
   const popoverButtonRef = useRef<HTMLButtonElement>(null);
 
+  const blockHintKey = e => {
+    if (e.altKey && e.code === 'KeyH') {
+      e.preventDefault();
+    }
+  };
+
   const toggleShow = e => {
-    e.preventDefault();
     const lastActiveElement = window.document.activeElement;
 
-    if (e.altKey && e.key.toLowerCase() === 'h') {
+    if (e.altKey && e.code === 'KeyH') {
+      e.preventDefault();
       popoverButtonRef.current.click();
       (lastActiveElement as HTMLElement).focus();
     }
   };
 
+  useEventListener('keydown', blockHintKey);
   useEventListener('keyup', toggleShow);
 
   return (

--- a/src/components/Shortcut.tsx
+++ b/src/components/Shortcut.tsx
@@ -9,8 +9,14 @@ const Shortcut = ({ command }: Props) => {
 
   const altKey = isMacOS() ? '⌥' : 'Alt';
 
-  const readableCommand = command.replace(/\+/g, ' + ').replace(/alt/g, altKey).toUpperCase();
-
+  const readableCommand = command
+    .replace(/\+/g, ' + ')
+    .replace(/alt/g, altKey)
+    .split(' ')
+    .map(token =>
+      token.length === 1 && /[a-zA-Z]/.test(token) ? token.toLowerCase() : token.toUpperCase(),
+    )
+    .join(' ');
   return (
     <div
       role="button"


### PR DESCRIPTION
Bug: Show Answer shortcut (Alt/Option + H) not working on macOS

The previous implementation used e.key.toLowerCase() === 'h' to handle both h and H (Shift+H). However, on macOS, Option+H does not produce 'h' or 'H' — it produces the dead accent character '˙', and Option+Shift+H produces 'Ó'. Neither matches 'h' after .toLowerCase(), so the shortcut was silently broken for all Mac users.

Fix: Replaced e.key with e.code === 'KeyH', which targets the physical key position rather than the character output. This works correctly for ⌥h, ⌥H, and ⌥⇧H on all platforms regardless of OS keyboard mappings.

Also added a keydown + preventDefault listener on the regex input to stop the ˙ character from being inserted when the shortcut is triggered while the input is focused.