### PR TITLE
fix: stop production redirect loop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,57 @@
 module.exports = {
   reactStrictMode: true,
   output: 'export',
+  async rewrites() {
+    return [
+      {
+        source: '/',
+        destination: '/en',
+      },
+      {
+        source: '/learn',
+        destination: '/en/learn',
+      },
+      {
+        source: '/learn/:lesson*',
+        destination: '/en/learn/:lesson*',
+      },
+      {
+        source: '/cheatsheet',
+        destination: '/en/cheatsheet',
+      },
+      {
+        source: '/playground',
+        destination: '/en/playground',
+      },
+    ];
+  },
+  async redirects() {
+    return [
+      {
+        source: '/en',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/en/learn',
+        destination: '/learn',
+        permanent: true,
+      },
+      {
+        source: '/en/learn/:lesson*',
+        destination: '/learn/:lesson*',
+        permanent: true,
+      },
+      {
+        source: '/en/cheatsheet',
+        destination: '/cheatsheet',
+        permanent: true,
+      },
+      {
+        source: '/en/playground',
+        destination: '/playground',
+        permanent: true,
+      },
+    ];
+  },
 };

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,0 @@
-/en               /                    301
-/en/learn         /learn               301
-/en/learn/*       /learn/:splat        301
-/en/cheatsheet    /cheatsheet          301
-/en/playground    /playground          301


### PR DESCRIPTION
Restores the legacy Next.js English-route rewrite and redirect configuration and removes the Cloudflare Pages public/_redirects file that causes the custom domain to redirect / back to itself. The production Pages domain serves the export correctly, while regexlearn.com currently returns Location: / for / and triggers ERR_TOO_MANY_REDIRECTS. Removing the generated Pages redirects breaks that loop; physical English fallback pages remain exported for /, /learn, /cheatsheet, /playground, and both lessons. Validated with npm run lint, npm run build, a 134-page static export, absence of out/_redirects, and presence of both out/index.html and out/en.html.